### PR TITLE
Fix package URL in commentary

### DIFF
--- a/laas.el
+++ b/laas.el
@@ -8,7 +8,7 @@
 ;; Modified: February 13, 2021
 ;; Version: 0.2
 ;; Keywords: tools, tex
-;; Homepage: https://github.com/tecosaur/auto-latex-auto-activating-snippets
+;; Homepage: https://github.com/tecosaur/LaTeX-auto-activating-snippets
 ;; Package-Requires: ((emacs "26.3") (auctex "11.88") (aas "0.2") (yasnippet "0.14"))
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;


### PR DESCRIPTION
* `laas.el`: Fix package URL in commentary.

---

When I try to open the package homepage from Emacs's package manager, my browser shows a "404 Not Found" response.  This PR should resolve the issue.