### PR TITLE
(bug): Fix multi-subscript skipped over closing brace

### DIFF
--- a/laas.el
+++ b/laas.el
@@ -55,7 +55,8 @@ insert a new subscript (e.g a -> a_1)."
      (backward-char)
      (insert "{")
      (forward-char)
-     (insert s "}"))))
+     (insert s "}")
+     (backward-char))))
 
 (defun laas-mathp ()
   "Determine whether point is within a LaTeX maths block."


### PR DESCRIPTION
Before if you tried to do `x5` -> `x_5` and then `x_51` -> `x_{51}`
your point would be moved outside of the closing brace so if you wanted
to add more to the body of the subscript you couldn't. Now you're kept
in there and have to exit the closing brace manually.