### PR TITLE
Fix unhandled case in laas-wrap-previous-object

### DIFF
--- a/laas.el
+++ b/laas.el
@@ -145,7 +145,7 @@ and is expected to return a string or cons."
      (t
       (message "Wrong type of `tex-cmd' given to `laas-wrap-previous-object'.")))
     ;; wrap
-    (when left
+    (when (and left start)
       (insert right)
       (save-excursion
         (goto-char start)


### PR DESCRIPTION
start might be nil (if there is a space to the left for example) and this causes this function to insert text to the right then error.